### PR TITLE
Change PVST build env to bullseye on 202311.X

### DIFF
--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -54,41 +54,44 @@ jobs:
       runBranch: 'refs/heads/master'
     displayName: "Download sonic swss common deb packages"
 
-  - task: DownloadPipelineArtifact@2
-    inputs:
-      source: specific
-      project: build
-      pipeline: 465
-      ${{ if eq(parameters.arch, 'amd64') }}:
-        artifact: common-lib
-      ${{ else }}:
-        artifact: common-lib.${{ parameters.arch }}
-      runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/master'
-      patterns: |
-        target/debs/bookworm/libyang*.deb
-        target/debs/bookworm/libnl*.deb
-    displayName: "Download bookworm debs"
+  # - task: DownloadPipelineArtifact@2
+  #   inputs:
+  #     source: specific
+  #     project: build
+  #     pipeline: 465
+  #     ${{ if eq(parameters.arch, 'amd64') }}:
+  #       artifact: common-lib
+  #     ${{ else }}:
+  #       artifact: common-lib.${{ parameters.arch }}
+  #     runVersion: 'latestFromBranch'
+  #     runBranch: 'refs/heads/master'
+  #     patterns: |
+  #       target/debs/bookworm/libyang*.deb
+  #       target/debs/bookworm/libnl*.deb
+  #   displayName: "Download bookworm debs"
 
   - script: |
       set -ex
       ls -l ../
       pwd
-      find /usr/lib -name libevent.a
 
       #install HIREDIS
       sudo apt-get install -y libhiredis0.14 libhiredis-dev
 
       # LIBYANG
-      sudo dpkg -i ../target/debs/bookworm/libyang*1.0.73*.deb
+      # sudo dpkg -i ../target/debs/bookworm/libyang*1.0.73*.deb
 
       # Install libnl3
-      sudo apt-get -y purge libnl-3-dev libnl-route-3-dev || true
-      sudo dpkg -i ../target/debs/bookworm/libnl-3-200_*.deb
-      sudo dpkg -i ../target/debs/bookworm/libnl-genl-3-200_*.deb
-      sudo dpkg -i ../target/debs/bookworm/libnl-route-3-200_*.deb
-      sudo dpkg -i ../target/debs/bookworm/libnl-nf-3-200_*.deb
-      #sudo apt-get install -qq -y libnl-3-dev libnl-genl-3-dev libnl-route-3-dev libnl-nf-3-dev
+      # sudo apt-get -y purge libnl-3-dev libnl-route-3-dev || true
+      # sudo dpkg -i ../target/debs/bookworm/libnl-3-200_*.deb
+      # sudo dpkg -i ../target/debs/bookworm/libnl-genl-3-200_*.deb
+      # sudo dpkg -i ../target/debs/bookworm/libnl-route-3-200_*.deb
+      # sudo dpkg -i ../target/debs/bookworm/libnl-nf-3-200_*.deb
+      sudo apt-get install -qq -y libnl-3-dev libnl-genl-3-dev libnl-route-3-dev libnl-nf-3-dev
+
+      # Install libevent-2.1-12
+      sudo apt-get update
+      sudo apt-get install -y libevent-2.1-7
 
       #install libswsscommon
       sudo dpkg -i ../libswsscommon_1.0.0_${{ parameters.arch }}.deb

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,32 +17,22 @@ pr:
 
 stages:
 - stage: Build
-
   jobs:
-  - template: .azure-pipelines/build-template.yml
-    parameters:
-      arch: amd64
-      sonic_slave: sonic-slave-bookworm
-      swss_common_artifact_name: sonic-swss-common
-      artifact_name: sonic-stp
+  - job:
+    pool: sonicbld
+    displayName: "build"
+    timeoutInMinutes: 60
+    steps:
+    - checkout: self
+      clean: true
+      submodules: recursive
+      displayName: 'Checkout code'
+    - script: |
+        echo Hello
+        # the following is copied from jenkins
+        # set -ex
+        # ./scripts/common/sonic-stp-build/build.sh'
+    - publish: $(System.DefaultWorkingDirectory)/target/
+      artifact: sonic-stp
+      displayName: "Archive artifacts"
 
-- stage: BuildArm
-  dependsOn: []
-  jobs:
-#  - template: .azure-pipelines/build-template.yml
-#    parameters:
-#      arch: armhf
-#      timeout: 180
-#      pool: sonicbld-armhf
-#      sonic_slave: sonic-slave-bookworm-armhf
-#      swss_common_artifact_name: sonic-swss-common.armhf
-#      artifact_name: sonic-stp.armhf
-
-  - template: .azure-pipelines/build-template.yml
-    parameters:
-      arch: arm64
-      timeout: 180
-      pool: sonicbld-arm64
-      sonic_slave: sonic-slave-bookworm-arm64
-      swss_common_artifact_name: sonic-swss-common.arm64
-      artifact_name: sonic-stp.arm64


### PR DESCRIPTION
Support PVST on 202311.X branch

#### Why I did it
Need to support this feature on 202311.X branch.

#### How I did it
Change build env to bullseye.

#### How to verify it
Merge related commits on sonic-swss and docker-stp to build image to make sure it works fine.