### PR TITLE
Restore packed declaration on packet-related structs.

### DIFF
--- a/include/l2.h
+++ b/include/l2.h
@@ -84,7 +84,7 @@ typedef struct LLC_HEADER
 	BYTE destination_address_DSAP;
 	BYTE source_address_SSAP;
 	BYTE llc_frame_type;
-} __attribute__((aligned(1))) LLC_HEADER;
+} __attribute__((__packed__)) LLC_HEADER;
 
 typedef struct SNAP_HEADER
 {
@@ -95,13 +95,13 @@ typedef struct SNAP_HEADER
 
 	BYTE protocol_id_filler[3];
 	UINT16 protocol_id;
-} __attribute__((aligned(2))) SNAP_HEADER;
+} __attribute__((__packed__)) SNAP_HEADER;
 
 typedef struct MAC_ADDRESS
 {
 	UINT32 _ulong;
 	UINT16 _ushort;
-} __attribute__((aligned(4))) MAC_ADDRESS;
+} __attribute__((__packed__)) MAC_ADDRESS;
 
 #define COPY_MAC(sptr_mac2, sptr_mac1) \
 	(memcpy(sptr_mac2, sptr_mac1, sizeof(MAC_ADDRESS)))
@@ -121,7 +121,7 @@ typedef struct MAC_HEADER
 	MAC_ADDRESS source_address;
 
 	USHORT length;
-} __attribute__((aligned(4))) MAC_HEADER;
+} __attribute__((__packed__)) MAC_HEADER;
 
 #define STP_BPDU_OFFSET (sizeof(MAC_HEADER) + sizeof(LLC_HEADER))
 #define PVST_BPDU_OFFSET (sizeof(MAC_HEADER) + sizeof(SNAP_HEADER))

--- a/include/stp_common.h
+++ b/include/stp_common.h
@@ -62,7 +62,7 @@ typedef struct BRIDGE_BPDU_FLAGS
 	UINT8 blank : 6;
 	UINT8 topology_change_acknowledgement : 1;
 #endif
-} __attribute__((aligned(1))) BRIDGE_BPDU_FLAGS;
+} __attribute__((packed)) BRIDGE_BPDU_FLAGS;
 
 typedef struct BRIDGE_IDENTIFIER
 {
@@ -76,7 +76,7 @@ typedef struct BRIDGE_IDENTIFIER
 
 	MAC_ADDRESS address;
 
-} __attribute__((aligned(4))) BRIDGE_IDENTIFIER;
+} __attribute__((packed)) BRIDGE_IDENTIFIER;
 
 typedef struct PORT_IDENTIFIER
 {
@@ -87,7 +87,7 @@ typedef struct PORT_IDENTIFIER
 	UINT16 number : 12;
 	UINT16 priority : 4;
 #endif // BIG_ENDIAN
-} __attribute__((aligned(2))) PORT_IDENTIFIER;
+} __attribute__((packed)) PORT_IDENTIFIER;
 
 // spanning-tree configuration bpdu
 typedef struct STP_CONFIG_BPDU
@@ -106,7 +106,7 @@ typedef struct STP_CONFIG_BPDU
 	UINT16 max_age;
 	UINT16 hello_time;
 	UINT16 forward_delay;
-} __attribute__((aligned(4))) STP_CONFIG_BPDU;
+} __attribute__((packed)) STP_CONFIG_BPDU;
 
 // spanning-tree topology change notification bpdu
 typedef struct STP_TCN_BPDU
@@ -117,7 +117,7 @@ typedef struct STP_TCN_BPDU
 	UINT8 protocol_version_id;
 	UINT8 type;
 	UINT8 padding[3];
-} __attribute__((aligned(4))) STP_TCN_BPDU;
+} __attribute__((packed)) STP_TCN_BPDU;
 
 // pvst configuration bpdu
 typedef struct PVST_CONFIG_BPDU
@@ -139,7 +139,7 @@ typedef struct PVST_CONFIG_BPDU
 	UINT8 padding[3];
 	UINT16 tag_length;
 	UINT16 vlan_id;
-} __attribute__((aligned(4))) PVST_CONFIG_BPDU;
+} __attribute__((packed)) PVST_CONFIG_BPDU;
 
 // pvst topology change notification bpdu
 typedef struct PVST_TCN_BPDU
@@ -150,6 +150,6 @@ typedef struct PVST_TCN_BPDU
 	UINT8 protocol_version_id;
 	UINT8 type;
 	UINT8 padding[38];
-} __attribute__((aligned(4))) PVST_TCN_BPDU;
+} __attribute__((packed)) PVST_TCN_BPDU;
 
 #endif //__STP_COMMON_H__


### PR DESCRIPTION
**What I did**
Packet-related structs must use the packed attribute; without it the TX packet size exceeds 68 bytes, which is incorrect. It also causes the `stpd` daemon to crash.

**Why I did it**
Fix stpd crash issue. 
After enable spanning-tree and add a link-up port to be a VLAN member, stpd will crashed.
`Apr 29 07:54:07.298858 as9716-32d-2 INFO stp#stp#supervisord: stpd *** buffer overflow detected ***: terminated`
`Apr 29 07:54:08.099122 as9716-32d-2 INFO stp#stp#supervisord 2025-04-29 07:54:08,098 INFO exited: stpd (terminated by SIGABRT (core dumped); not expected)`
`Apr 29 07:54:09.104039 as9716-32d-2 INFO stp#stp#supervisor-proc-exit-listener: Process 'stpd' exited unexpectedly. Terminating supervisor 'stp'`

**How I verified it**
Make sure stpd works fine after enable spanning-tree and add a link-up port to be a VLAN member.
Dump pvst packet to make sure it is correct.