### PR TITLE
Get the maximum port number from the PORT_TABLE in APPDB instead of calculating it from netdevs.

### DIFF
--- a/include/stp_externs.h
+++ b/include/stp_externs.h
@@ -179,7 +179,7 @@ extern uint32_t stp_intf_get_kif_index_by_port_id(uint32_t port_id);
 extern uint32_t stp_intf_get_port_id_by_name(char *ifname);
 extern INTERFACE_NODE *stp_intf_get_node_by_name(char *ifname);
 extern struct event_base *stp_intf_get_evbase();
-extern int stp_intf_event_mgr_init(void);
+extern int stp_intf_event_mgr_init(UINT16 max_port_id);
 extern int stp_intf_avl_compare(const void *user_p, const void *data_p, void *param);
 extern void stp_intf_netlink_cb(struct netlink_db_s *if_db, uint8_t is_add, bool init_in_prog);
 extern void stp_intf_reset_port_params();

--- a/include/stp_ipc.h
+++ b/include/stp_ipc.h
@@ -71,8 +71,9 @@ typedef struct STP_IPC_MSG
 
 typedef struct STP_INIT_READY_MSG
 {
-    uint8_t opcode; // enable/disable
-    uint16_t max_stp_instances;
+    uint8_t     opcode; // enable/disable
+    uint16_t    max_stp_instances;
+    uint16_t    max_port_number;
 } __attribute__((aligned(4))) STP_INIT_READY_MSG;
 
 typedef struct STP_BRIDGE_CONFIG_MSG

--- a/stp/stp_intf.c
+++ b/stp/stp_intf.c
@@ -586,7 +586,7 @@ int stp_intf_init_po_id_pool()
 }
 
 
-int stp_intf_event_mgr_init(void)
+int stp_intf_event_mgr_init(UINT16 max_port_id)
 {
     struct event *nl_event = 0;
 
@@ -607,6 +607,12 @@ int stp_intf_event_mgr_init(void)
     {
         STP_LOG_CRITICAL("error in intf db creation");
         sys_assert(0);
+    }
+
+    if (g_max_stp_port < max_port_id)
+    {
+        /* use the same calculation formula with original g_max_stp_port */
+        g_max_stp_port = max_port_id + (4 - (max_port_id % 4));
     }
 
     /* This is not expected. Reboot the container to recover */

--- a/stp/stp_mgr.c
+++ b/stp/stp_mgr.c
@@ -1829,7 +1829,7 @@ static void stpmgr_process_ipc_msg(STP_IPC_MSG *msg, int len, struct sockaddr_un
             {
                 STP_INIT_READY_MSG *pmsg = (STP_INIT_READY_MSG *)msg->data;
                 /* All ports are initialized in the system. Now build IF DB in STP */
-                ret = stp_intf_event_mgr_init();
+                ret = stp_intf_event_mgr_init(pmsg->max_port_number);
                 if(ret == -1)
                     return;
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Get the maximum port number from the PORT_TABLE in APPDB instead of calculating it from netdevs.

**Why I did it**
During a fast reboot: when stpmgrd informs stpd that ports are ready, some network devices (netdevs) may not be fully created yet. As a result, stpd calculates a lower-than-actual maximum port number, leading to insufficient memory allocation.

**How I verified it**
Execute 'fast-reboot' to make sure the maximum port number is correct.

**Details if related**
```
Aug 15 13:42:35.421788 as9736-64d-4 INFO stp#stp#stpd: stp_intf_event_mgr_init:619:intf db done. max port 1032
Aug 15 06:12:08.821033 as9736-64d-4 INFO stp#stp#stpd: stp_intf_event_mgr_init:613:intf db done. max port 1032
Aug 15 06:23:44.033068 as9736-64d-4 INFO stp#stp#stpd: stp_intf_event_mgr_init:619:intf db done. max port 1032
Aug 15 06:26:57.789474 as9736-64d-4 INFO stp#stp#stpd: stp_intf_event_mgr_init:619:intf db done. max port 1032
Aug 15 06:31:11.628875 as9736-64d-4 INFO stp#stp#stpd: stp_intf_event_mgr_init:619:intf db done. max port 1032
Aug 15 06:37:44.771785 as9736-64d-4 INFO stp#stp#stpd: stp_intf_event_mgr_init:619:intf db done. max port 1032
```

**Notes**
Related to https://github.com/edge-core/sonic-swss/pull/142.