### PR TITLE
Fixed missing declaration variables

### DIFF
--- a/stp/stp_intf.c
+++ b/stp/stp_intf.c
@@ -588,6 +588,7 @@ int stp_intf_init_po_id_pool()
 
 int stp_intf_event_mgr_init(UINT16 max_port_id)
 {
+    int ret = 0;
     struct event *nl_event = 0;
 
     if((g_stpd_ioctl_sock = socket(AF_INET, SOCK_STREAM, 0)) < 0)


### PR DESCRIPTION
**What I did**
Fixed missing declaration variables
**Why I did it**
Fixed bruild error
**How I verified it**
build stp deb passed on local
```
ubuntu@ip-10-5-1-155:~/workspace/SONiC-Harden/SONiC-GITHUB-Build-Harden-202311.X/sonic-buildimage (202311.X)$ make target/debs/bullseye/stp_1.0.0_amd64.deb
+++ --- Making target/debs/bullseye/stp_1.0.0_amd64.deb --- +++
./scripts/run_with_retry make EXTRA_DOCKER_TARGETS=stp_1.0.0_amd64.deb BLDENV=buster -f Makefile.work buster
make[1]: Entering directory '/home/ubuntu/workspace/SONiC-Harden/SONiC-GITHUB-Build-Harden-202311.X/sonic-buildimage'
"SECURE_UPGRADE_PROD_SIGNING_TOOL": ""
~/workspace/SONiC-Harden/SONiC-GITHUB-Build-Harden-202311.X/sonic-buildimage/src/sonic-build-hooks ~/workspace/SONiC-Harden/SONiC-GITHUB-Build-Harden-202311.X/sonic-buildimage
make[2]: Entering directory '/home/ubuntu/workspace/SONiC-Harden/SONiC-GITHUB-Build-Harden-202311.X/sonic-buildimage/src/sonic-build-hooks'
dpkg-deb: building package 'sonic-build-hooks' in 'buildinfo/sonic-build-hooks_1.0_all.deb'.
make[2]: Leaving directory '/home/ubuntu/workspace/SONiC-Harden/SONiC-GITHUB-Build-Harden-202311.X/sonic-buildimage/src/sonic-build-hooks'
~/workspace/SONiC-Harden/SONiC-GITHUB-Build-Harden-202311.X/sonic-buildimage
Checking sonic-slave-base image: sonic-slave-buster:747db51d46d
Checking sonic-slave-user image: sonic-slave-buster-ubuntu:8daad34637c
SONiC Build System

Build Configuration
"CONFIGURED_PLATFORM"             : "broadcom"
"CONFIGURED_ARCH"                 : "amd64"
"SONIC_CONFIG_PRINT_DEPENDENCIES" : "y"
"SONIC_BUILD_JOBS"                : "1"
"SONIC_CONFIG_MAKE_JOBS"          : "2"
"USE_NATIVE_DOCKERD_FOR_BUILD"    : ""
"SONIC_USE_DOCKER_BUILDKIT"       : ""
"USERNAME"                        : "admin"
"PASSWORD"                        : "YourPaSsWoRd"
"CHANGE_DEFAULT_PASSWORD"         : "n"
"SECURE_UPGRADE_MODE"             : "no_sign"
"SECURE_UPGRADE_DEV_SIGNING_KEY"  : ""
"SECURE_UPGRADE_SIGNING_CERT" : ""
"SECURE_UPGRADE_PROD_SIGNING_TOOL": ""
"SECURE_UPGRADE_PROD_TOOL_ARGS"   : ""
"ONIE_IMAGE_PART_SIZE"            : ""
"ENABLE_DHCP_GRAPH_SERVICE"       : ""
"SHUTDOWN_BGP_ON_START"           : ""
"ENABLE_PFCWD_ON_START"           : ""
"SONIC_BUFFER_MODEL"              : ""
"INSTALL_DEBUG_TOOLS"             : ""
"ROUTING_STACK"                   : "frr"
"FRR_USER_UID"                    : "300"
"FRR_USER_GID"                    : "300"
"ENABLE_SYNCD_RPC"                : ""
"SAITHRIFT_V2"                    : ""
"ENABLE_ORGANIZATION_EXTENSIONS"  : "y"
"HTTP_PROXY"                      : ""
"HTTPS_PROXY"                     : ""
"NO_PROXY"                        : ""
"ENABLE_ZTP"                      : "y"
"INCLUDE_PDE"                     : ""
"SONIC_DEBUGGING_ON"              : ""
"SONIC_PROFILING_ON"              : ""
"KERNEL_PROCURE_METHOD"           : "build"
"BUILD_TIMESTAMP"                 : "20250818.053823"
"BUILD_LOG_TIMESTAMP"             : "none"
"SONIC_IMAGE_VERSION"             : "202311.X.0-ecsai-20250818.053823"
"BLDENV"                          : "buster"
"VS_PREPARE_MEM"                  : "yes"
"INCLUDE_MGMT_FRAMEWORK"          : "y"
"INCLUDE_ICCPD"                   : "y"
"INCLUDE_STP"                     : "y"
"INCLUDE_SYSTEM_TELEMETRY"        : "n"
"INCLUDE_SYSTEM_GNMI"             : "y"
"INCLUDE_SYSTEM_EVENTD"           : "y"
"ENABLE_HOST_SERVICE_ON_START"    : "y"
"INCLUDE_RESTAPI"                 : "n"
"INCLUDE_SFLOW"                   : "y"
"INCLUDE_NAT"                     : "y"
"INCLUDE_DHCP_RELAY"              : "y"
"INCLUDE_DHCP_SERVER"             : "n"
"INCLUDE_P4RT"                    : "n"
"INCLUDE_KUBERNETES"              : "y"
"INCLUDE_KUBERNETES_MASTER"       : "n"
"INCLUDE_MACSEC"                  : "y"
"INCLUDE_MUX"                     : "y"
"INCLUDE_TEAMD"                   : "y"
"INCLUDE_ROUTER_ADVERTISER"       : "y"
"INCLUDE_BOOTCHART                : "y"
"ENABLE_BOOTCHART                 : "n"
"INCLUDE_FIPS"             : "y"
"ENABLE_TRANSLIB_WRITE"           : "y"
"ENABLE_NATIVE_WRITE"             : "y"
"ENABLE_DIALOUT"                  : ""
"ENABLE_AUTO_TECH_SUPPORT"        : "y"
"PDDF_SUPPORT"                    : "y"
"MULTIARCH_QEMU_ENVIRON"          : "n"
"SONIC_VERSION_CONTROL_COMPONENTS": "none"
"ENABLE_ASAN"                     : "n"
"DEFAULT_CONTAINER_REGISTRY"      : ""
"CROSS_BUILD_ENVIRON"             : "n"
"GZ_COMPRESS_PROGRAM"             : "gzip"
"LEGACY_SONIC_MGMT_DOCKER"        : "y"

fatal: not a git repository (or any of the parent directories): .git
"SONIC_DPKG_CACHE_METHOD"         : "rwcache"
"DPKG_CACHE_PATH"                 : "/var/cache/sonic/artifacts"

[ DPKG ] Cache is not enabled for stp_1.0.0_amd64.deb package
[ DPKG ] Cache is not enabled for genl-packet-module_1.0-1_amd64.deb package
[ DPKG ] Cache is not enabled for sonic-platform-nokia-chassis_1.0_amd64.deb package
[ DPKG ] Cache is not enabled for sonic-platform-ufispace-s9300-32d_1.0.0_amd64.deb package
[ DPKG ] Cache is not enabled for libsaicredo_0.9.3_amd64.deb package
[ DPKG ] Cache is not enabled for libsaicredo-owl_0.9.3_amd64.deb package
[ DPKG ] Cache is not enabled for libsaibroncos_3.11_amd64.deb package
DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. pip 21.0 will drop support for Python 2.7 in January 2021. More details about Python 2 support in pip can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support pip 21.0 will remove support for this functionality.
make[1]: Leaving directory '/home/ubuntu/workspace/SONiC-Harden/SONiC-GITHUB-Build-Harden-202311.X/sonic-buildimage'
./scripts/run_with_retry make BLDENV=bullseye -f Makefile.work target/debs/bullseye/stp_1.0.0_amd64.deb
make[1]: Entering directory '/home/ubuntu/workspace/SONiC-Harden/SONiC-GITHUB-Build-Harden-202311.X/sonic-buildimage'
"SECURE_UPGRADE_PROD_SIGNING_TOOL": ""
~/workspace/SONiC-Harden/SONiC-GITHUB-Build-Harden-202311.X/sonic-buildimage/src/sonic-build-hooks ~/workspace/SONiC-Harden/SONiC-GITHUB-Build-Harden-202311.X/sonic-buildimage
make[2]: Entering directory '/home/ubuntu/workspace/SONiC-Harden/SONiC-GITHUB-Build-Harden-202311.X/sonic-buildimage/src/sonic-build-hooks'
dpkg-deb: building package 'sonic-build-hooks' in 'buildinfo/sonic-build-hooks_1.0_all.deb'.
make[2]: Leaving directory '/home/ubuntu/workspace/SONiC-Harden/SONiC-GITHUB-Build-Harden-202311.X/sonic-buildimage/src/sonic-build-hooks'
~/workspace/SONiC-Harden/SONiC-GITHUB-Build-Harden-202311.X/sonic-buildimage
Checking sonic-slave-base image: sonic-slave-bullseye:b852ce10ed4
Checking sonic-slave-user image: sonic-slave-bullseye-ubuntu:4c6950517b5
SONiC Build System

Build Configuration
"CONFIGURED_PLATFORM"             : "broadcom"
"CONFIGURED_ARCH"                 : "amd64"
"SONIC_CONFIG_PRINT_DEPENDENCIES" : "y"
"SONIC_BUILD_JOBS"                : "1"
"SONIC_CONFIG_MAKE_JOBS"          : "2"
"USE_NATIVE_DOCKERD_FOR_BUILD"    : ""
"SONIC_USE_DOCKER_BUILDKIT"       : ""
"USERNAME"                        : "admin"
"PASSWORD"                        : "YourPaSsWoRd"
"CHANGE_DEFAULT_PASSWORD"         : "n"
"SECURE_UPGRADE_MODE"             : "no_sign"
"SECURE_UPGRADE_DEV_SIGNING_KEY"  : ""
"SECURE_UPGRADE_SIGNING_CERT" : ""
"SECURE_UPGRADE_PROD_SIGNING_TOOL": ""
"SECURE_UPGRADE_PROD_TOOL_ARGS"   : ""
"ONIE_IMAGE_PART_SIZE"            : ""
"ENABLE_DHCP_GRAPH_SERVICE"       : ""
"SHUTDOWN_BGP_ON_START"           : ""
"ENABLE_PFCWD_ON_START"           : ""
"SONIC_BUFFER_MODEL"              : ""
"INSTALL_DEBUG_TOOLS"             : ""
"ROUTING_STACK"                   : "frr"
"FRR_USER_UID"                    : "300"
"FRR_USER_GID"                    : "300"
"ENABLE_SYNCD_RPC"                : ""
"SAITHRIFT_V2"                    : ""
"ENABLE_ORGANIZATION_EXTENSIONS"  : "y"
"HTTP_PROXY"                      : ""
"HTTPS_PROXY"                     : ""
"NO_PROXY"                        : ""
"ENABLE_ZTP"                      : "y"
"INCLUDE_PDE"                     : ""
"SONIC_DEBUGGING_ON"              : ""
"SONIC_PROFILING_ON"              : ""
"KERNEL_PROCURE_METHOD"           : "build"
"BUILD_TIMESTAMP"                 : "20250818.054003"
"BUILD_LOG_TIMESTAMP"             : "none"
"SONIC_IMAGE_VERSION"             : "202311.X.0-ecsai-20250818.054003"
"BLDENV"                          : "bullseye"
"VS_PREPARE_MEM"                  : "yes"
"INCLUDE_MGMT_FRAMEWORK"          : "y"
"INCLUDE_ICCPD"                   : "y"
"INCLUDE_STP"                     : "y"
"INCLUDE_SYSTEM_TELEMETRY"        : "n"
"INCLUDE_SYSTEM_GNMI"             : "y"
"INCLUDE_SYSTEM_EVENTD"           : "y"
"ENABLE_HOST_SERVICE_ON_START"    : "y"
"INCLUDE_RESTAPI"                 : "n"
"INCLUDE_SFLOW"                   : "y"
"INCLUDE_NAT"                     : "y"
"INCLUDE_DHCP_RELAY"              : "y"
"INCLUDE_DHCP_SERVER"             : "n"
"INCLUDE_P4RT"                    : "n"
"INCLUDE_KUBERNETES"              : "y"
"INCLUDE_KUBERNETES_MASTER"       : "n"
"INCLUDE_MACSEC"                  : "y"
"INCLUDE_MUX"                     : "y"
"INCLUDE_TEAMD"                   : "y"
"INCLUDE_ROUTER_ADVERTISER"       : "y"
"INCLUDE_BOOTCHART                : "y"
"ENABLE_BOOTCHART                 : "n"
"INCLUDE_FIPS"             : "y"
"ENABLE_TRANSLIB_WRITE"           : "y"
"ENABLE_NATIVE_WRITE"             : "y"
"ENABLE_DIALOUT"                  : ""
"ENABLE_AUTO_TECH_SUPPORT"        : "y"
"PDDF_SUPPORT"                    : "y"
"MULTIARCH_QEMU_ENVIRON"          : "n"
"SONIC_VERSION_CONTROL_COMPONENTS": "none"
"ENABLE_ASAN"                     : "n"
"DEFAULT_CONTAINER_REGISTRY"      : ""
"CROSS_BUILD_ENVIRON"             : "n"
"GZ_COMPRESS_PROGRAM"             : "gzip"
"LEGACY_SONIC_MGMT_DOCKER"        : "y"

"SONIC_DPKG_CACHE_METHOD"         : "rwcache"
"DPKG_CACHE_PATH"                 : "/var/cache/sonic/artifacts"

[ DPKG ] Cache is not enabled for genl-packet-module_1.0-1_amd64.deb package
[ DPKG ] Cache is not enabled for stp_1.0.0_amd64.deb package
[ DPKG ] Cache is not enabled for sonic-platform-nokia-chassis_1.0_amd64.deb package
[ DPKG ] Cache is not enabled for sonic-platform-ufispace-s9300-32d_1.0.0_amd64.deb package
[ DPKG ] Cache is not enabled for libsaicredo_0.9.3_amd64.deb package
[ DPKG ] Cache is not enabled for libsaicredo-owl_0.9.3_amd64.deb package
[ DPKG ] Cache is not enabled for libsaibroncos_3.11_amd64.deb package
make[1]: Leaving directory '/home/ubuntu/workspace/SONiC-Harden/SONiC-GITHUB-Build-Harden-202311.X/sonic-buildimage'
BLDENV=bullseye make -f Makefile.work docker-cleanup
make[1]: Entering directory '/home/ubuntu/workspace/SONiC-Harden/SONiC-GITHUB-Build-Harden-202311.X/sonic-buildimage'
"SECURE_UPGRADE_PROD_SIGNING_TOOL": ""
~/workspace/SONiC-Harden/SONiC-GITHUB-Build-Harden-202311.X/sonic-buildimage/src/sonic-build-hooks ~/workspace/SONiC-Harden/SONiC-GITHUB-Build-Harden-202311.X/sonic-buildimage
make[2]: Entering directory '/home/ubuntu/workspace/SONiC-Harden/SONiC-GITHUB-Build-Harden-202311.X/sonic-buildimage/src/sonic-build-hooks'
dpkg-deb: building package 'sonic-build-hooks' in 'buildinfo/sonic-build-hooks_1.0_all.deb'.
make[2]: Leaving directory '/home/ubuntu/workspace/SONiC-Harden/SONiC-GITHUB-Build-Harden-202311.X/sonic-buildimage/src/sonic-build-hooks'
~/workspace/SONiC-Harden/SONiC-GITHUB-Build-Harden-202311.X/sonic-buildimage
make[1]: Leaving directory '/home/ubuntu/workspace/SONiC-Harden/SONiC-GITHUB-Build-Harden-202311.X/sonic-buildimage'
```